### PR TITLE
Fixed "url.parse is not a function" and joining url paths returning "[]"

### DIFF
--- a/lib/cas-helper-functions.js
+++ b/lib/cas-helper-functions.js
@@ -760,12 +760,12 @@ function getCasCycleUrl(req, path, query) {
 
 function joinUrlPath(...paths) {
   let res = [];
-  for (let p of paths) res.concat(p.split("/"))
+  for (let p of paths) res = res.concat(p.split("/"))
   return res.filter((p) => p.length).join("/");
 }
 
-function formatUrl(url, path, query) {
-  let comp = url.parse(url);
+function formatUrl(uri, path, query) {
+  let comp = url.parse(uri);
   return url.format(
     Object.assign(comp, {
       pathname: joinUrlPath(comp.pathname, path),


### PR DESCRIPTION
A little oversight from PR #2 