### PR TITLE
Expose block method

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,5 +165,6 @@ module.exports = {
   casHandler,
   casRouter,
   getSessionInfo,
-  ensureSession
+  ensureSession,
+  block: casHelpers.block
 };


### PR DESCRIPTION
To expose a middleware that checks if the user is logged in, but doesn't redirect to the CAS server like casHandler does