### PR TITLE
Don't create session if it doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The setup consists of 3 steps:
 2. _after_ a session middleware, "use" this CAS authentication middleware
 3. add the `casHandler` middleware function to the routes delivering the client
 
+This lib will throw an error if no session object is found!
+
 ### Include lib and initialize it
 
 The only initialization parameters are the URL of the CAS server and explicitly setting the backendBaseUrl to `false`:

--- a/lib/cas-authentication.js
+++ b/lib/cas-authentication.js
@@ -125,7 +125,7 @@ function getTicketFromLogoutRequest(body) {
  * login page.
  */
 function bounce_redirect(req, res, next) {
-  casHelpers.checkSession();
+  casHelpers.checkSession(req);
   // If the session has been validated with CAS, no action is required.
   if (req.session[options.sessionName]) {
     if (req.query.redirectTo) {
@@ -143,7 +143,7 @@ function bounce_redirect(req, res, next) {
  * Redirects the client to the CAS login.
  */
 function login(req, res, next) {
-  casHelpers.checkSession();
+  casHelpers.checkSession(req);
   // Save the return URL in the session. If an explicit return URL is set as a
   // query parameter, use that. Otherwise, just use the URL from the request.
   req.session.cas_return_to =

--- a/lib/cas-authentication.js
+++ b/lib/cas-authentication.js
@@ -3,6 +3,7 @@ var request = require("request");
 var parseXML = require("xml2js").parseString;
 var XMLprocessors = require("xml2js/lib/processors");
 const logger = require("./logger");
+const casHelpers = require("./cas-helper-functions");
 
 /**
  * CAS options
@@ -124,6 +125,7 @@ function getTicketFromLogoutRequest(body) {
  * login page.
  */
 function bounce_redirect(req, res, next) {
+  casHelpers.checkSession();
   // If the session has been validated with CAS, no action is required.
   if (req.session[options.sessionName]) {
     if (req.query.redirectTo) {
@@ -141,6 +143,7 @@ function bounce_redirect(req, res, next) {
  * Redirects the client to the CAS login.
  */
 function login(req, res, next) {
+  casHelpers.checkSession();
   // Save the return URL in the session. If an explicit return URL is set as a
   // query parameter, use that. Otherwise, just use the URL from the request.
   req.session.cas_return_to =

--- a/lib/cas-helper-functions.js
+++ b/lib/cas-helper-functions.js
@@ -87,7 +87,7 @@ function casLogin(req, res, next) {
   req.query.returnTo = req.query.target;
 
   // remember deep link in session
-  req.session = req.session || {};
+  checkSession();
   if (req.query.target) {
     req.session[options.session_targetUrl] = req.query.target;
     logger.silly("set returnTo to " + req.query.target);
@@ -116,6 +116,7 @@ function casLogin(req, res, next) {
 function redirectToFrontend(req, res) {
   var ticket;
   var targetUrl;
+  checkSession();
   const target = req.session[options.session_targetUrl] || options.frontend_url;
 
   logger.info("redirecting to target");
@@ -265,7 +266,7 @@ function startAppSession(req, username, userData) {
 
   // start session
   // -------------
-  req.session = req.session || {};
+  checkSession();
   req.session[options.sessionName] = username;
   sessionId = generateSessionId(options.tokenLength);
   currentTickets.push({
@@ -404,6 +405,7 @@ function registerOptions(_options) {
 }
 
 function getTargetUrl(req) {
+  checkSession();
   var targetUrl = req.session && req.session[options.session_targetUrl];
 
   if (targetUrl) {
@@ -540,7 +542,8 @@ function init(_options) {
  * build the full (absolute) URL
  *
  * @param {()} req
- */ function fullUrl(req) {
+ */
+function fullUrl(req) {
   return url.format({
     protocol: req.protocol,
     host: req.get("host"),
@@ -552,7 +555,8 @@ function init(_options) {
  * build the full (absolute) URL
  *
  * @param {()} req
- */ function fullUrl2(urlComponents) {
+ */
+function fullUrl2(urlComponents) {
   return url.format({
     protocol: urlComponents.protocol,
     host: urlComponents.host,
@@ -633,6 +637,12 @@ function formatUrl(uri, path, query) {
   );
 }
 
+function checkSession() {
+  if (!req.session) {
+    throw new Error("No session object found");
+  }
+}
+
 module.exports = {
   block,
   possibleCasLogout,
@@ -650,5 +660,6 @@ module.exports = {
   getServiceUrl,
   getCasServerUrl,
   getCasCycleUrl,
-  getUrlPathToSelf
+  getUrlPathToSelf,
+  checkSession
 };

--- a/lib/cas-helper-functions.js
+++ b/lib/cas-helper-functions.js
@@ -87,7 +87,7 @@ function casLogin(req, res, next) {
   req.query.returnTo = req.query.target;
 
   // remember deep link in session
-  checkSession();
+  checkSession(req);
   if (req.query.target) {
     req.session[options.session_targetUrl] = req.query.target;
     logger.silly("set returnTo to " + req.query.target);
@@ -116,7 +116,7 @@ function casLogin(req, res, next) {
 function redirectToFrontend(req, res) {
   var ticket;
   var targetUrl;
-  checkSession();
+  checkSession(req);
   const target = req.session[options.session_targetUrl] || options.frontend_url;
 
   logger.info("redirecting to target");
@@ -266,7 +266,7 @@ function startAppSession(req, username, userData) {
 
   // start session
   // -------------
-  checkSession();
+  checkSession(req);
   req.session[options.sessionName] = username;
   sessionId = generateSessionId(options.tokenLength);
   currentTickets.push({
@@ -405,7 +405,7 @@ function registerOptions(_options) {
 }
 
 function getTargetUrl(req) {
-  checkSession();
+  checkSession(req);
   var targetUrl = req.session && req.session[options.session_targetUrl];
 
   if (targetUrl) {
@@ -637,7 +637,7 @@ function formatUrl(uri, path, query) {
   );
 }
 
-function checkSession() {
+function checkSession(req) {
   if (!req.session) {
     throw new Error("No session object found");
   }


### PR DESCRIPTION
`req.session = req.session || {}` was throwing an error when one property of `session` was only a getter. And according to the readme this middleware should be used after a session middleware, so the session should already be created => error when no session is found.